### PR TITLE
support composite primary key

### DIFF
--- a/lib/skippa/table.rb
+++ b/lib/skippa/table.rb
@@ -69,6 +69,8 @@ module Skippa
                     v.dig(1)
                   when :symbol #symbol
                     v.dig(1, 1)
+                  when Array # array of string/symbol
+                    v.map{|s| s.dig(1, 1, 1)}
                   end
                 else
                   v

--- a/test/skippa/table_test.rb
+++ b/test/skippa/table_test.rb
@@ -5,21 +5,25 @@ class TableTest < Minitest::Test
   def setup
     @access_log_table = access_log_table()
     @users_table = users_table()
+    @composite_pkey_table = composite_pkey_table()
   end
 
   def test_name
     assert_equal "access_log", @access_log_table.name
     assert_equal "users", @users_table.name
+    assert_equal "composite_pkey", @composite_pkey_table.name
   end
 
   def test_options
     assert_equal({ "id" => "false", "force" => "cascade" }, @access_log_table.options)
     assert_equal({ "force" => "cascade" }, @users_table.options)
+    assert_equal({ "id" => "false", "force" => "cascade", "primary_key" => ["pkey1", "pkey2"] }, @composite_pkey_table.options)
   end
 
   def test_columns
     assert_equal ["user_id", "timestamp"], @access_log_table.columns.map(&:name)
     assert_equal ["email", "password"], @users_table.columns.map(&:name)
+    assert_equal ["pkey1", "pkey2", "timestamp"], @composite_pkey_table.columns.map(&:name)
   end
 
   private
@@ -39,6 +43,18 @@ __EOD__
 create_table "users", force: :cascade do |t|
   t.string "email", limit: 255, default: "", null: false
   t.string "password", limit: 255, default: "", null: false
+end
+__EOD__
+    sexp = Ripper.sexp(doc).dig(1, 0)
+    Skippa::Table.parse(sexp)
+  end
+  
+  def composite_pkey_table
+    doc = <<'__EOD__'
+create_table "composite_pkey", id: false, force: :cascade, primary_key: [:pkey1, :pkey2] do |t|
+  t.string "pkey1"
+  t.integer "pkey2"
+  t.datetime "timestamp", limit: 8
 end
 __EOD__
     sexp = Ripper.sexp(doc).dig(1, 0)


### PR DESCRIPTION
Hi!
If there is an Array in the create_table's option value, it seems to return nil.

Actually, my schema.rb has a compposite primary key table. its
```Table#options['primary_key']``` returns nil.

Please take a look!


