### PR TITLE
add support table definition index and unique_constraint.

### DIFF
--- a/lib/skippa.rb
+++ b/lib/skippa.rb
@@ -4,6 +4,8 @@ require "skippa/extention"
 require "skippa/table"
 require "skippa/column"
 require "skippa/index"
+require "skippa/table_definition_index"
+require "skippa/table_definition_unique_constraint"
 
 require "ripper"
 

--- a/lib/skippa/schema.rb
+++ b/lib/skippa/schema.rb
@@ -87,10 +87,16 @@ module Skippa
     end
 
     def indexes
-      sexp
+      table_indexes = self.tables
+        .map { |table| table.indexes }
+        .flatten
+
+      add_indexes = sexp
         .dig(2, 2, 1)
         .select { |method_add_block| method_add_block.dig(1, 1) == "add_index" rescue false }
         .map { |method_add_block| Skippa::Index.parse(method_add_block)}
+
+      [*table_indexes, *add_indexes]
     end
   end
 end

--- a/lib/skippa/table_definition_index.rb
+++ b/lib/skippa/table_definition_index.rb
@@ -1,0 +1,76 @@
+module Skippa
+  class TableDefinitionIndex
+    # https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html#method-i-index
+
+    class << self
+      def parse(sexp, table_name)
+        new(sexp, table_name)
+      end
+    end
+
+    attr_reader :sexp
+
+    def initialize(sexp, table_name)
+      @sexp = sexp
+      @table_name = table_name
+    end
+
+    def inspect
+      "#<#{self.class.inspect}:#{self.object_id.inspect} table_name=#{self.table_name.inspect}, column_names=#{self.column_names.inspect}, options=#{self.options.inspect}>"
+    end
+
+    def pretty_print(q)
+      q.group(2, "#<#{self.class.inspect}:#{self.object_id.inspect}") do
+        q.breakable
+        q.text "table_name="
+        q.pp self.table_name
+        q.text(",")
+
+        q.breakable
+        q.text "column_names="
+        q.pp self.column_names
+        q.text ","
+
+        q.breakable
+        q.text "options="
+        q.pp self.options
+        q.text ","
+      end
+      q.breakable
+      q.text(">")
+    end
+
+    def table_name
+      @table_name
+    end
+
+    def column_names
+      sexp
+        .dig(4, 1, 0, 1)
+        .map { |array| array.dig(1, 1, 1) }
+    end
+
+    def options
+      key_value_array = Array(sexp.dig(4, 1, 1, 1)).flat_map do |assoc_new|
+        key = assoc_new.dig(1, 1).chop # chop `:`
+        value = case v = assoc_new.dig(2, 1)
+                when [:string_content]
+                  # empty string
+                  ""
+                when Array
+                  # symbol or string
+                  case v2 = v.dig(1)
+                  when Array
+                    v2.dig(1)
+                  else
+                    v2
+                  end
+                else
+                  v
+                end
+        [key, value]
+      end
+      Hash[*key_value_array]
+    end
+  end
+end

--- a/lib/skippa/table_definition_unique_constraint.rb
+++ b/lib/skippa/table_definition_unique_constraint.rb
@@ -1,0 +1,76 @@
+module Skippa
+  class TableDefinitionUniqueConstraint
+    # https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQL/TableDefinition.html#method-i-unique_constraint
+
+    class << self
+      def parse(sexp, table_name)
+        new(sexp, table_name)
+      end
+    end
+
+    attr_reader :sexp
+
+    def initialize(sexp, table_name)
+      @sexp = sexp
+      @table_name = table_name
+    end
+
+    def inspect
+      "#<#{self.class.inspect}:#{self.object_id.inspect} table_name=#{self.table_name.inspect}, column_names=#{self.column_names.inspect}, options=#{self.options.inspect}>"
+    end
+
+    def pretty_print(q)
+      q.group(2, "#<#{self.class.inspect}:#{self.object_id.inspect}") do
+        q.breakable
+        q.text "table_name="
+        q.pp self.table_name
+        q.text(",")
+
+        q.breakable
+        q.text "column_names="
+        q.pp self.column_names
+        q.text ","
+
+        q.breakable
+        q.text "options="
+        q.pp self.options
+        q.text ","
+      end
+      q.breakable
+      q.text(">")
+    end
+
+    def table_name
+      @table_name
+    end
+
+    def column_names
+      sexp
+        .dig(4, 1, 0, 1)
+        .map { |array| array.dig(1, 1, 1) }
+    end
+
+    def options
+      key_value_array = Array(sexp.dig(4, 1, 1, 1)).flat_map do |assoc_new|
+        key = assoc_new.dig(1, 1).chop # chop `:`
+        value = case v = assoc_new.dig(2, 1)
+                when [:string_content]
+                  # empty string
+                  ""
+                when Array
+                  # symbol or string
+                  case v2 = v.dig(1)
+                  when Array
+                    v2.dig(1)
+                  else
+                    v2
+                  end
+                else
+                  v
+                end
+        [key, value]
+      end
+      Hash[*key_value_array]
+    end
+  end
+end

--- a/lib/skippa/version.rb
+++ b/lib/skippa/version.rb
@@ -1,3 +1,3 @@
 module Skippa
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/test/skippa/schema_test.rb
+++ b/test/skippa/schema_test.rb
@@ -18,6 +18,11 @@ ActiveRecord::Schema.define(version: 20180522032741) do
     t.string "password", limit: 255, default: "", null: false
   end
 
+  create_table "tbl", force: :cascade do |t|
+    t.string "col", limit: 255, default: "", null: false
+    t.index ["col"], name: "index_col_on_tbl"
+  end
+
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 end
 __EOD__
@@ -34,10 +39,10 @@ __EOD__
   end
 
   def test_tables
-    assert_equal ["access_log", "users"], @schema.tables.map(&:name)
+    assert_equal ["access_log", "users", "tbl"], @schema.tables.map(&:name)
   end
 
   def test_indexes
-    assert_equal ["index_users_on_email"], @schema.indexes.map { |index| index.options["name"] }
+    assert_equal ["index_col_on_tbl", "index_users_on_email"], @schema.indexes.map { |index| index.options["name"] }
   end
 end

--- a/test/skippa/table_definition_index_test.rb
+++ b/test/skippa/table_definition_index_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+require "ripper"
+
+class TableDefinitionIndexTest < Minitest::Test
+  def setup
+    @user_id_index = user_id_index()
+  end
+
+  def test_column_names
+    assert_equal ["user_id"], @user_id_index.column_names
+  end
+
+  def test_options
+    assert_equal({ "name" => "index_tbl_on_user_id" }, @user_id_index.options)
+  end
+
+  def test_table_name
+    assert_equal "tbl", @user_id_index.table_name
+  end
+
+  private
+  def user_id_index
+    doc = <<'__EOD__'
+t.index ["user_id"], name: "index_tbl_on_user_id"
+__EOD__
+    sexp = Ripper.sexp(doc).dig(1, 0)
+    Skippa::TableDefinitionIndex.parse(sexp, "tbl")
+  end
+end

--- a/test/skippa/table_definition_unique_constraint_test.rb
+++ b/test/skippa/table_definition_unique_constraint_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+require "ripper"
+
+class TableDefinitionUniqueConstraintTest < Minitest::Test
+  def setup
+    @id1_id2_id3_unique_constraint = id1_id2_id3_unique_constraint()
+  end
+
+  def test_column_names
+    assert_equal ["id1", "id2", "id3"], @id1_id2_id3_unique_constraint.column_names
+  end
+
+  def test_options
+    assert_equal({ "name" => "tbl_id1_id2_id3" }, @id1_id2_id3_unique_constraint.options)
+  end
+
+  def test_table_name
+    assert_equal "tbl", @id1_id2_id3_unique_constraint.table_name
+  end
+
+  private
+  def id1_id2_id3_unique_constraint
+    doc = <<'__EOD__'
+t.unique_constraint ["id1", "id2", "id3"], name: "tbl_id1_id2_id3"
+__EOD__
+    sexp = Ripper.sexp(doc).dig(1, 0)
+    Skippa::TableDefinitionUniqueConstraint.parse(sexp, "tbl")
+  end
+end

--- a/test/skippa/table_test.rb
+++ b/test/skippa/table_test.rb
@@ -6,24 +6,66 @@ class TableTest < Minitest::Test
     @access_log_table = access_log_table()
     @users_table = users_table()
     @composite_pkey_table = composite_pkey_table()
+    @indexes_table = indexes_table()
+    @unique_constraints_table = unique_constraints_table()
   end
 
   def test_name
     assert_equal "access_log", @access_log_table.name
     assert_equal "users", @users_table.name
     assert_equal "composite_pkey", @composite_pkey_table.name
+    assert_equal "indexes_table", @indexes_table.name
+    assert_equal "unique_constraints_table", @unique_constraints_table.name
   end
 
   def test_options
     assert_equal({ "id" => "false", "force" => "cascade" }, @access_log_table.options)
     assert_equal({ "force" => "cascade" }, @users_table.options)
     assert_equal({ "id" => "false", "force" => "cascade", "primary_key" => ["pkey1", "pkey2"] }, @composite_pkey_table.options)
+    assert_equal({ "force" => "cascade" }, @indexes_table.options)
+    assert_equal({ "force" => "cascade" }, @unique_constraints_table.options)
   end
 
   def test_columns
     assert_equal ["user_id", "timestamp"], @access_log_table.columns.map(&:name)
     assert_equal ["email", "password"], @users_table.columns.map(&:name)
     assert_equal ["pkey1", "pkey2", "timestamp"], @composite_pkey_table.columns.map(&:name)
+    assert_equal ["col1", "col2", "col3"], @indexes_table.columns.map(&:name)
+    assert_equal ["col1", "col2", "col3"], @unique_constraints_table.columns.map(&:name)
+  end
+
+  def test_indexes
+    assert_equal [], @access_log_table.indexes
+    assert_equal [], @users_table.indexes
+    assert_equal [], @composite_pkey_table.indexes
+    assert_equal [], @unique_constraints_table.indexes
+
+    assert_equal [
+      ["col1"],
+      ["col2"],
+      ["col2", "col3"],
+    ], @indexes_table.indexes.map(&:column_names)
+    assert_equal [
+      "index_indexes_table_on_col1",
+      "index_indexes_table_on_col2",
+      "index_indexes_table_on_col2_col3",
+    ], @indexes_table.indexes.map{ |index| index.options["name"] }
+  end
+
+  def test_unique_constraints
+    assert_equal [], @access_log_table.unique_constraints
+    assert_equal [], @users_table.unique_constraints
+    assert_equal [], @composite_pkey_table.unique_constraints
+    assert_equal [], @indexes_table.unique_constraints
+
+    assert_equal [
+      ["col1"],
+      ["col2", "col3"],
+    ], @unique_constraints_table.unique_constraints.map(&:column_names)
+    assert_equal [
+      "unique_constraints_table_col1_key",
+      "unique_constraints_table_col2_col3_key",
+    ], @unique_constraints_table.unique_constraints.map{ |index| index.options["name"] }
   end
 
   private
@@ -55,6 +97,35 @@ create_table "composite_pkey", id: false, force: :cascade, primary_key: [:pkey1,
   t.string "pkey1"
   t.integer "pkey2"
   t.datetime "timestamp", limit: 8
+end
+__EOD__
+    sexp = Ripper.sexp(doc).dig(1, 0)
+    Skippa::Table.parse(sexp)
+  end
+
+  def indexes_table
+    doc = <<'__EOD__'
+create_table "indexes_table", force: :cascade do |t|
+  t.string "col1"
+  t.integer "col2"
+  t.integer "col3"
+  t.index ["col1"], name: "index_indexes_table_on_col1"
+  t.index ["col2"], name: "index_indexes_table_on_col2"
+  t.index ["col2", "col3"], name: "index_indexes_table_on_col2_col3"
+end
+__EOD__
+    sexp = Ripper.sexp(doc).dig(1, 0)
+    Skippa::Table.parse(sexp)
+  end
+
+  def unique_constraints_table
+    doc = <<'__EOD__'
+create_table "unique_constraints_table", force: :cascade do |t|
+  t.string "col1"
+  t.integer "col2"
+  t.integer "col3"
+  t.unique_constraint ["col1"], name: "unique_constraints_table_col1_key"
+  t.unique_constraint ["col2", "col3"], name: "unique_constraints_table_col2_col3_key"
 end
 __EOD__
     sexp = Ripper.sexp(doc).dig(1, 0)


### PR DESCRIPTION
Hello, it's been a while.

I tried schema.rb in Rails 7.2 and found the following output in the table definition.
I'm adding this parsing process.

  * index
  * unique_constraint (Postgres only)
